### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install pyqt5
 ```
 git clone https://github.com/vascocosta/glueather.git
 cd glueather
-pyhton -m venv venv
+python -m venv venv
 source venv/bin/activate
 pip install pyowm
 pip install pyqt5
@@ -69,7 +69,7 @@ pip install pyqt5
 ```
 git clone https://github.com/vascocosta/glueather.git
 cd glueather
-pyhton -m venv venv
+python -m venv venv
 venv\Scripts\activate
 pip install pyowm
 pip install pyqt5


### PR DESCRIPTION
Misspelled Python as Pyhton. ;)

On a sidenote, why not replace the separate `pip install` commands in the venv section with `pip install -r requirements.txt`?